### PR TITLE
Add validation for .psmi file extension

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,13 +26,13 @@ int main(int argc, char* argv[]) {
 
     if (argc > 1) {
         std::string filePath = argv[1];
-        if (filePath.find(".psmi") == std::string::npos) {
+        if (filePath.size() < 5 || filePath.substr(filePath.size() - 5 != ".psmi") {
             std::cerr << "Error: File must have a .psmi extension." << std::endl;
             return 1;
         }
         input = readSourceCodeFromFile(filePath);
     } else {
-        std::cerr << "Usage: " << argv[0] << " <source file.psmi>" << std::endl;
+        std::cerr << "Usage: " << argv[0] << " <source_file.psmi>" << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
This check isn't as strict as the substr() method because it will succeed even if .psmi appears in the middle of the file path e.g: "folder.psmi/file.txt". If you specifically want to validate that the file ends with .psmi, you should stick with the substr() approach.


## Pull Request Checklist

### Description
- [x] Provide a short summary of the changes introduced in this pull request.

### Related Issues
- [ ] Does this pull request address any open issues? If so, link them here:
  - Issue link: `#<issue-number>`

### Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Code improvement/refactoring
- [ ] Documentation update
- [ ] Other (Please describe): 

### Testing
- [ ] Have you added tests for your changes?
- [ ] Did you run all the tests locally and ensure they are passing? 
  - [ ] Yes
  - [x] No (Please explain):

### Checklist
- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have documented any new functionality or updated existing documentation.
- [ ] I have made corresponding changes to the **README.md** (if applicable).
- [ ] I have ensured the changes are backward-compatible (if applicable).

### Additional Information
- [ ] Any additional comments or information that would be helpful for reviewers:
